### PR TITLE
Fixed typos in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Introduction
 This an unofficial Patreon SDK for iOS. It not endorsed or affiliated with Patreon. Nevertheless I hope you will find it useful as there is no official SDK currently.
 
-The project is written in Swift 4 and makes use of *Codable* for seamless JSON parsing. Minimum supported iOS is 8.0. The repo contains a *Patreon.xcodeproj* which produces the SDK in the form of a dynamic framework. There is also a sample app project to demontrate use of the SDK.
+The project is written in Swift 4 and makes use of *Codable* for seamless JSON parsing. Minimum supported iOS is 8.0. The repo contains a *Patreon.xcodeproj* which produces the SDK in the form of a dynamic framework. There is also a sample app project to demonstrate use of the SDK.
 
 The SDK is light and self contained without requiring any external dependencies.
 
@@ -26,7 +26,7 @@ Each method offers several overloads (e.g. allowing to provide an access token a
 ## Authentication
 So far the SDK does not handle authentication. You are responsible of authenticating the user and obtaining the Access Token. There are 2 strategies for that:
 * Use the **Creator's Access Token**. Make sure you don't bundle it with the app as this is a security risk. The best way it to use on-demand resources to download it after installing the app and then directly write it to the keychain. The SDK will automatically check in the keychain for the key named "AccessToken" before making each request and use it if it's there.
-* Use **OAuth2 authentication** within the app. However this is not so straitforward as it requires a server component to complete the authentication process securely. For now this is not supported. You will have to figure it out on your own.
+* Use **OAuth2 authentication** within the app. However this is not so straightforward as it requires a server component to complete the authentication process securely. For now this is not supported. You will have to figure it out on your own.
 
 ## API Resources
 The SDK can access 3 different resources from the API


### PR DESCRIPTION
"demontrate" -> "demonstrate"
"straitforward" -> "straightforward"